### PR TITLE
Muth/fix v0.9.6

### DIFF
--- a/installer/build-script.sh
+++ b/installer/build-script.sh
@@ -13,6 +13,7 @@
 #
 #
 
+set -x
 force_install=false
 for arg in "$@"
 do

--- a/installer/build-script.sh
+++ b/installer/build-script.sh
@@ -13,7 +13,6 @@
 #
 #
 
-set -x
 force_install=false
 for arg in "$@"
 do

--- a/installer/build-script.sh
+++ b/installer/build-script.sh
@@ -69,7 +69,9 @@ else
 fi
 
 # make sure kitchen sink is available
+/usr/bin/bash -x << EOF
 ${INSTALLER_CMD}
+EOF
 
 # script is running in root directory of extracted files
 


### PR DESCRIPTION
Previous checking broke KM release process. Expanded `${INSTALLER_CMD}` wasn't getting interpretation. This fixes that.