### PR TITLE
Support both low memory and high memory configs

### DIFF
--- a/kkm/Makefile
+++ b/kkm/Makefile
@@ -22,7 +22,7 @@ KERNEL_VERSION := $(shell uname -r)
 KDIR ?= /lib/modules/${KERNEL_VERSION}/build
 
 ifneq (${VALGRIND},)
-KKM_EXTRA_FLAGS := ccflags-y="KM_GPA_AT_16T=1"
+KKM_EXTRA_FLAGS := ccflags-y="-DKM_GPA_AT_16T=1"
 else
 KKM_EXTRA_FLAGS :=
 endif

--- a/kkm/Makefile
+++ b/kkm/Makefile
@@ -22,7 +22,7 @@ KERNEL_VERSION := $(shell uname -r)
 KDIR ?= /lib/modules/${KERNEL_VERSION}/build
 
 ifneq (${VALGRIND},)
-KKM_EXTRA_FLAGS := ccflags-y="-DKM_GPA_AT_16T=1"
+KKM_EXTRA_FLAGS := ccflags-y="KM_GPA_AT_16T=1"
 else
 KKM_EXTRA_FLAGS :=
 endif

--- a/kkm/Makefile
+++ b/kkm/Makefile
@@ -21,9 +21,15 @@ endif
 KERNEL_VERSION := $(shell uname -r)
 KDIR ?= /lib/modules/${KERNEL_VERSION}/build
 
+ifneq (${VALGRIND},)
+KKM_EXTRA_FLAGS := ccflags-y="-DKM_GPA_AT_16T=1"
+else
+KKM_EXTRA_FLAGS :=
+endif
+
 default:
 	@echo "Building KKM module"
-	$(MAKE) -C $(KDIR) M=$(CURRENT_DIR)
+	$(MAKE) -C $(KDIR) M=$(CURRENT_DIR) $(KKM_EXTRA_FLAGS)
 	objdump -d kkm.ko > kkm.dis
 	objdump -S kkm.ko > kkm.s.dis
 

--- a/kkm/kkm_externs.h
+++ b/kkm/kkm_externs.h
@@ -47,8 +47,13 @@
 /*
  * monitor mapping area for guest physical memory
  */
+#ifndef KM_GPA_AT_16T
 #define KKM_KM_USER_MEM_BASE                                                   \
 	(0x000000000000ULL) /* keep in sync with KM_USER_MEM_BASE */
+#else
+#define KKM_KM_USER_MEM_BASE                                                   \
+	(0x100000000000ULL) /* keep in sync with KM_USER_MEM_BASE */
+#endif
 
 #define KKM_KM_GUEST_PRIVATE_MEM_START_VA (512 * KKM_GIB)
 

--- a/kkm/kkm_mmu.h
+++ b/kkm/kkm_mmu.h
@@ -156,7 +156,11 @@
  *     virtual address for stack growing down
  */
 /* bytes offset into pml4 table for 16TB(monitor guest mapping) */
+#ifndef KM_GPA_AT_16T
 #define KKM_PGD_MONITOR_PAYLOAD_ENTRY (0)
+#else
+#define KKM_PGD_MONITOR_PAYLOAD_ENTRY (32)
+#endif
 #define KKM_PGD_MONITOR_PAYLOAD_ENTRY_OFFSET (KKM_PGD_MONITOR_PAYLOAD_ENTRY * 8)
 /* byte offset into pml4 payload virtual address for code */
 #define KKM_PGD_GUEST_PAYLOAD_BOTTOM_ENTRY (0)


### PR DESCRIPTION
valgrind doesn't work with high memory (guest == km addresses). For valgrind runs we compile km with high memory - guest address = km address - 16TB. That also needs to be supported by kkm, hence this change.

The km repo right now refers to the commit on the branch. After this is merged we will point km to the appropriate commit here