### PR TITLE
5level page table support

### DIFF
--- a/kkm/kkm.h
+++ b/kkm/kkm.h
@@ -196,14 +196,30 @@ struct kkm {
 	struct mutex pf_lock;
 
 	/*
-	 * guest kernel pml4 page
+	 * guest kernel pgd page
 	 */
-	struct kkm_mmu_page_info gk_pml4;
+	struct kkm_mmu_page_info gk_pgd;
 
 	/*
-	 * guest payload pml4 page
+	 * guest payload pgd page
 	 */
-	struct kkm_mmu_page_info gp_pml4;
+	struct kkm_mmu_page_info gp_pgd;
+
+	/*
+	 * guest kernel p4d page
+	 */
+	struct kkm_mmu_page_info gk_p4d;
+
+	/*
+	 * guest payload p4d page
+	 */
+	struct kkm_mmu_page_info gp_p4d;
+
+	/*
+	 * page for low address
+	 * same table is used for kernel and payload p4d for low addresses
+	 */
+	struct kkm_mmu_page_info low_p4d;
 
 	/*
 	 * guest private area page table hierarchy

--- a/kkm/kkm_kontainer.c
+++ b/kkm/kkm_kontainer.c
@@ -167,6 +167,13 @@ void kkm_kontainer_cleanup_p4d_pages(struct kkm *kkm)
  */
 void kkm_kontainer_cleanup(struct kkm *kkm)
 {
+	if (kkm->low_p4d.page != NULL) {
+		kkm_mm_free_pages(kkm->low_p4d.va,
+				  KKM_KONTAINER_LOW_PAGE_COUNT);
+		kkm->low_p4d.page = NULL;
+		kkm->low_p4d.va = 0;
+		kkm->low_p4d.pa = 0;
+	}
 	kkm_cleanup_pml4(&kkm->kkm_guest_pml4e);
 	kkm_kontainer_cleanup_pgd_pages(kkm);
 	kkm_kontainer_cleanup_p4d_pages(kkm);

--- a/kkm/kkm_kontainer.c
+++ b/kkm/kkm_kontainer.c
@@ -31,47 +31,97 @@
 #define KKM_USER_PGTABLE_BIT (PAGE_SHIFT)
 #define KKM_USER_PGTABLE_MASK (1 << KKM_USER_PGTABLE_BIT)
 
-#define KKM_KONTAINER_PML4_PAGE_COUNT (2)
+#define KKM_KONTAINER_LVL_PAGE_COUNT (2)
+#define KKM_KONTAINER_LOW_PAGE_COUNT (1)
+
+int kkm_kontainer_allocate_lvl_pages(struct kkm_mmu_page_info *k_page,
+				     struct kkm_mmu_page_info *p_page)
+{
+	int ret_val = 0;
+
+	/*
+	 * allocate 2 pages
+	 */
+	ret_val = kkm_mm_allocate_pages(&k_page->page, &k_page->va, &k_page->pa,
+					KKM_KONTAINER_LVL_PAGE_COUNT);
+	if (ret_val != 0) {
+		printk(KERN_NOTICE
+		       "kkm_kontainer_allocate_lvl_pages: Failed to allocate memory for guest kernel page table error(%d)\n",
+		       ret_val);
+		return ret_val;
+	}
+
+	if (((uint64_t)k_page->va & KKM_USER_PGTABLE_MASK) ==
+	    KKM_USER_PGTABLE_MASK) {
+		printk(KERN_ERR
+		       "kkm_kontainer_allocate_lvl_pages: unexpected odd start page address\n");
+		ret_val = -EINVAL;
+		return ret_val;
+	}
+
+	/*
+	 * allocate 2 pages,
+	 *     kernel mode
+	 *     guest mode
+	 * kernel code depends on kernel page table at even page and user page table at next(odd) page
+	 */
+	p_page->va = k_page->va + PAGE_SIZE;
+	p_page->pa = k_page->pa + PAGE_SIZE;
+
+	return ret_val;
+}
+
+int kkm_kontainer_allocate_pgd_pages(struct kkm *kkm)
+{
+	return kkm_kontainer_allocate_lvl_pages(&kkm->gk_pgd, &kkm->gp_pgd);
+}
+
+int kkm_kontainer_allocate_p4d_pages(struct kkm *kkm)
+{
+	return kkm_kontainer_allocate_lvl_pages(&kkm->gk_p4d, &kkm->gp_p4d);
+}
 
 int kkm_kontainer_init(struct kkm *kkm)
 {
 	int ret_val = 0;
 
-	/*
-	 * allocated pages for pml4
-	 */
-	ret_val = kkm_mm_allocate_pages(&kkm->gk_pml4.page, &kkm->gk_pml4.va,
-					&kkm->gk_pml4.pa,
-					KKM_KONTAINER_PML4_PAGE_COUNT);
+	ret_val = kkm_kontainer_allocate_pgd_pages(kkm);
 	if (ret_val != 0) {
 		printk(KERN_NOTICE
-		       "kkm_kontainer_init: Failed to allocate memory for guest kernel page table error(%d)\n",
+		       "kkm_kontainer_init: pgd page allocation failed error(%d)\n",
 		       ret_val);
 		goto error;
 	}
 
-	if (((uint64_t)kkm->gk_pml4.va & KKM_USER_PGTABLE_MASK) ==
-	    KKM_USER_PGTABLE_MASK) {
-		printk(KERN_ERR
-		       "kkm_kontainer_init: unexpected odd start page address\n");
-		ret_val = -EINVAL;
-		goto error;
-	}
+	if (pgtable_l5_enabled() == true) {
+		ret_val = kkm_kontainer_allocate_p4d_pages(kkm);
+		if (ret_val != 0) {
+			printk(KERN_NOTICE
+			       "kkm_kontainer_init: p4d page allocation failed error(%d)\n",
+			       ret_val);
+			goto error;
+		}
 
-	/*
-	 * allocate 2 pages,
-	 *     kernel mode pml4
-	 *     guest mode pml4
-	 * kernel code depends on kernel page table at even page and user page table at next(odd) page
-	 */
-	kkm->gp_pml4.va = kkm->gk_pml4.va + PAGE_SIZE;
-	kkm->gp_pml4.pa += kkm->gk_pml4.pa + PAGE_SIZE;
+		/*
+		 * allocate low address page
+		 */
+		ret_val = kkm_mm_allocate_pages(&kkm->low_p4d.page,
+						&kkm->low_p4d.va,
+						&kkm->low_p4d.pa,
+						KKM_KONTAINER_LOW_PAGE_COUNT);
+		if (ret_val != 0) {
+			printk(KERN_NOTICE
+			       "kkm_kontainer_init: Failed to allocate memory for guest low pml4 page(%d)\n",
+			       ret_val);
+			return ret_val;
+		}
+	}
 
 	ret_val = kkm_create_pml4(&kkm->kkm_guest_pml4e,
 				  KKM_KM_GUEST_PRIVATE_MEM_START_VA);
 	if (ret_val != 0) {
 		printk(KERN_NOTICE
-		       "kkm_create_kontainer: guest areCopy kernel pgd entry failed error(%d)\n",
+		       "kkm_kontainer_init: guest area copy kernel pgd entry failed error(%d)\n",
 		       ret_val);
 		goto error;
 	}
@@ -87,21 +137,37 @@ error:
 	return ret_val;
 }
 
+void kkm_kontainer_cleanup_lvl_pages(struct kkm_mmu_page_info *k_page,
+				     struct kkm_mmu_page_info *p_page)
+{
+	if (k_page->page != NULL) {
+		kkm_mm_free_pages(k_page->va, KKM_KONTAINER_LVL_PAGE_COUNT);
+		k_page->page = NULL;
+
+		k_page->va = 0;
+		k_page->pa = 0;
+
+		p_page->va = 0;
+		p_page->pa = 0;
+	}
+}
+
+void kkm_kontainer_cleanup_pgd_pages(struct kkm *kkm)
+{
+	kkm_kontainer_cleanup_lvl_pages(&kkm->gk_pgd, &kkm->gp_pgd);
+}
+
+void kkm_kontainer_cleanup_p4d_pages(struct kkm *kkm)
+{
+	kkm_kontainer_cleanup_lvl_pages(&kkm->gk_p4d, &kkm->gp_p4d);
+}
+
 /*
  * cleanup
  */
 void kkm_kontainer_cleanup(struct kkm *kkm)
 {
 	kkm_cleanup_pml4(&kkm->kkm_guest_pml4e);
-	if (kkm->gk_pml4.page != NULL) {
-		kkm_mm_free_pages(kkm->gk_pml4.va,
-				  KKM_KONTAINER_PML4_PAGE_COUNT);
-		kkm->gk_pml4.page = NULL;
-
-		kkm->gk_pml4.va = 0;
-		kkm->gk_pml4.pa = 0;
-
-		kkm->gp_pml4.va = 0;
-		kkm->gp_pml4.pa = 0;
-	}
+	kkm_kontainer_cleanup_pgd_pages(kkm);
+	kkm_kontainer_cleanup_p4d_pages(kkm);
 }

--- a/kkm/kkm_kontext.c
+++ b/kkm/kkm_kontext.c
@@ -94,8 +94,8 @@ int kkm_kontext_init(struct kkm_kontext *kkm_kontext)
 	ga->kkm_kontext = kkm_kontext;
 	ga->guest_area_beg = (uint64_t)ga;
 
-	ga->guest_kernel_cr3 = kkm->gk_pml4.pa & ~PCID_MASK;
-	ga->guest_payload_cr3 = kkm->gp_pml4.pa & ~PCID_MASK;
+	ga->guest_kernel_cr3 = kkm->gk_pgd.pa & ~PCID_MASK;
+	ga->guest_payload_cr3 = kkm->gp_pgd.pa & ~PCID_MASK;
 	if (kkm_cpu_full_tlb_flush == false) {
 		ga->guest_kernel_cr3 |= GUEST_KERNEL_PCID;
 		ga->guest_payload_cr3 |= GUEST_PAYLOAD_PCID;
@@ -1011,10 +1011,10 @@ int kkm_process_page_fault(struct kkm_kontext *kkm_kontext,
 		 * we need to update page tables correctly
 		 */
 		if (priv_area == true) {
-			kkm_kontext_mmu_update_priv_area(ga->sregs.cr2,
-							 monitor_fault_address,
-							 (uint64_t)kkm->mm->pgd,
-							 &kkm->kkm_guest_pml4e);
+			kkm_mmu_update_priv_area(ga->sregs.cr2,
+						 monitor_fault_address,
+						 (uint64_t)kkm->mm->pgd,
+						 &kkm->kkm_guest_pml4e);
 		}
 
 		/*

--- a/kkm/kkm_main.c
+++ b/kkm/kkm_main.c
@@ -597,8 +597,8 @@ int kkm_set_kontainer_memory(struct kkm *kkm, unsigned long arg)
 		kkm->mem_slot_count++;
 	}
 
-	kkm_mmu_sync((uint64_t)kkm->mm->pgd, kkm->gk_pml4.va, kkm->gp_pml4.va,
-		     &kkm->kkm_guest_pml4e);
+	kkm_mmu_sync((uint64_t)kkm->mm->pgd, kkm->gk_pgd.va, kkm->gp_pgd.va,
+		     &kkm->kkm_guest_pml4e, kkm->low_p4d.va, kkm->low_p4d.pa);
 error:
 	mutex_unlock(&kkm->mem_lock);
 	if (ret_val != 0) {
@@ -711,7 +711,8 @@ int kkm_create_kontainer(unsigned long arg)
 	 * setup pml4 for guest kernel and guest payload
 	 */
 	ret_val = kkm_mmu_copy_kernel_pgd((uint64_t)kkm->mm->pgd,
-					  kkm->gk_pml4.va, kkm->gp_pml4.va);
+					  kkm->gk_pgd.va, kkm->gp_pgd.va,
+					  kkm->gk_p4d.va, kkm->gp_p4d.va);
 	if (ret_val != 0) {
 		printk(KERN_NOTICE
 		       "kkm_create_kontainer: Copy kernel pgd entry failed error(%d)\n",

--- a/kkm/kkm_mmu.c
+++ b/kkm/kkm_mmu.c
@@ -26,6 +26,68 @@
 struct kkm_mmu_pml4e kkm_mmu_kx;
 
 /*
+ * return current cpu private area first page table index
+ * next KKM_PER_CPU_GA_PAGE_COUNT belong to this physical cpu
+ */
+static int kkm_mmu_get_per_cpu_start_index(int cpu_index)
+{
+	int page_index =
+		KKM_CPU_GA_INDEX_START + cpu_index * KKM_PER_CPU_GA_PAGE_COUNT;
+	return page_index;
+}
+
+/*
+ * set one page table entry
+ */
+static void kkm_mmu_set_entry(void *pt_va, int index, uint64_t entry)
+{
+	((uint64_t *)pt_va)[index] = entry;
+}
+
+/*
+ * set one page table entry with given physical address and flags
+ */
+static void kkm_mmu_insert_page(void *pt_va, int index, phys_addr_t pa,
+				uint64_t flags)
+{
+	((uint64_t *)pt_va)[index] =
+		(pa & KKM_PAGE_PA_MASK) | (flags & KKM_PAGE_FLAGS_MASK);
+}
+
+static inline uint64_t kkm_mmu_entry_pa(uint64_t entry)
+{
+	return entry & PTE_PFN_MASK;
+}
+
+static bool kkm_mmu_get_table_va(uint64_t *table_va, int index)
+{
+	uint64_t entry;
+	uint64_t entry_pa;
+	uint64_t next_table_va;
+
+	/*
+	 * fetch entry from page table
+	 */
+	entry = ((uint64_t *)(*table_va))[index];
+
+	/*
+	 * get physical address of page from entry
+	 */
+	entry_pa = kkm_mmu_entry_pa(entry);
+
+	/*
+	 * convert physical address of page to kernel virtual address
+	 */
+	next_table_va = (uint64_t)phys_to_virt(entry_pa);
+
+	if (entry & _PAGE_PRESENT) {
+		*table_va = next_table_va;
+		return true;
+	}
+	return false;
+}
+
+/*
  * allocate pages and initialize pud, pmd, pt for private area
  */
 int kkm_mmu_init(void)
@@ -37,11 +99,6 @@ void kkm_mmu_cleanup(void)
 {
 	kkm_mmu_flush_tlb();
 	kkm_cleanup_pml4(&kkm_mmu_kx);
-}
-
-static inline uint64_t kkm_mmu_entry_pa(uint64_t entry)
-{
-	return entry & PTE_PFN_MASK;
 }
 
 /*
@@ -102,7 +159,7 @@ int kkm_create_pml4(struct kkm_mmu_pml4e *kmu, uint64_t address)
 
 	/* pages are allocated and zeroed, __GFP_ZERO flag is used to allocate page */
 
-	/* createp pgd entry */
+	/* create pgd entry */
 	kmu->pgd_entry = (kmu->pud.pa & KKM_PAGE_PA_MASK) | _PAGE_USER |
 			 _PAGE_RW | _PAGE_PRESENT;
 
@@ -137,46 +194,10 @@ void kkm_cleanup_pml4(struct kkm_mmu_pml4e *kmu)
 }
 
 /*
- * return pml4 entry for private memory area
- */
-uint64_t kkm_mmu_get_pgd_entry(void)
-{
-	return kkm_mmu_kx.pgd_entry;
-}
-
-/*
- * return current cpu private area first page table index
- * next KKM_PER_CPU_GA_PAGE_COUNT belong to this physical cpu
- */
-int kkm_mmu_get_per_cpu_start_index(int cpu_index)
-{
-	int page_index =
-		KKM_CPU_GA_INDEX_START + cpu_index * KKM_PER_CPU_GA_PAGE_COUNT;
-	return page_index;
-}
-
-/*
- * set one page table entry
- */
-void kkm_mmu_set_entry(void *pt_va, int index, uint64_t entry)
-{
-	((uint64_t *)pt_va)[index] = entry;
-}
-
-/*
- * set one page table entry with given physical address and flags
- */
-void kkm_mmu_insert_page(void *pt_va, int index, phys_addr_t pa, uint64_t flags)
-{
-	((uint64_t *)pt_va)[index] =
-		(pa & KKM_PAGE_PA_MASK) | (flags & KKM_PAGE_FLAGS_MASK);
-}
-
-/*
  * set this physicl cpu private area page table entries
  */
-void kkm_mmu_set_guest_area(int cpu_index, phys_addr_t pa0, phys_addr_t pa1, phys_addr_t pa2,
-			    phys_addr_t pa3)
+void kkm_mmu_set_guest_area(int cpu_index, phys_addr_t pa0, phys_addr_t pa1,
+			    phys_addr_t pa2, phys_addr_t pa3)
 {
 	int page_index = kkm_mmu_get_per_cpu_start_index(cpu_index);
 	uint64_t flags = _PAGE_NX | _PAGE_RW | _PAGE_PRESENT;
@@ -239,13 +260,65 @@ static void kkm_mmu_copy_range(uint64_t src_base, uint64_t src_offset,
 	       count);
 }
 
+static void kkm_mmu_setup_one_pgd(uint64_t kernel_pgd_base,
+				  void *pgd_table_base, void *p4d_table_base)
+{
+	uint64_t kernel_pgd_kx_p4d_entry_pa = 0;
+	uint64_t kernel_pgd_kx_p4d_entry_va = 0;
+
+	kkm_mmu_copy_range(kernel_pgd_base, KKM_PGD_KERNEL_OFFSET,
+			   (uint64_t)pgd_table_base, KKM_PGD_KERNEL_OFFSET,
+			   KKM_PGD_KERNEL_SIZE);
+
+	if (pgtable_l5_enabled() == true) {
+		if (p4d_table_base == NULL) {
+			printk(KERN_NOTICE
+			       "kkm_mmu_setup_one_pgd: P4D base is zero when pgtable_l5_enabled\n");
+			return;
+		}
+		/*
+		 * we have already copied top half of pgd from linux kernel to kkm pgd
+		 * replace pgd entry corresponding to KKM_KX_PGD_P4D_INDEX(511) to our p4d entry
+		 * copy entire p4d from native kernel to our p4d
+		 * replace entry KKM_KX_PGD_INDEX with kx entry
+		 */
+		kernel_pgd_kx_p4d_entry_pa =
+			((uint64_t *)kernel_pgd_base)[KKM_KX_PGD_P4D_INDEX] &
+			KKM_PAGE_PA_MASK;
+		kernel_pgd_kx_p4d_entry_va =
+			(uint64_t)phys_to_virt(kernel_pgd_kx_p4d_entry_pa);
+		kkm_mmu_copy_range(kernel_pgd_kx_p4d_entry_va, 0,
+				   (uint64_t)p4d_table_base, 0, PAGE_SIZE);
+
+		/*
+		 * set kx private area in p4d
+		 */
+		kkm_mmu_set_entry(p4d_table_base, KKM_KX_PGD_INDEX,
+				  kkm_mmu_kx.pgd_entry);
+
+		/*
+		 * set kx p4d entry in pgd
+		 */
+		kkm_mmu_insert_page(pgd_table_base, KKM_KX_PGD_P4D_INDEX,
+				    virt_to_phys(p4d_table_base),
+				    _PAGE_USER | _PAGE_RW | _PAGE_PRESENT);
+	} else {
+		/*
+		 * set kx private area in pgd
+		 */
+		kkm_mmu_set_entry(pgd_table_base, KKM_KX_PGD_INDEX,
+				  kkm_mmu_kx.pgd_entry);
+	}
+}
+
 /*
  * setup kernel memory range for 
  *     guest kernel
  *     guest payload
  */
 int kkm_mmu_copy_kernel_pgd(uint64_t current_pgd_base, void *guest_kernel_va,
-			    void *guest_payload_va)
+			    void *guest_payload_va, void *kernel_p4d_va,
+			    void *payload_p4d_va)
 {
 	if (current_pgd_base == 0) {
 		printk(KERN_NOTICE
@@ -253,15 +326,7 @@ int kkm_mmu_copy_kernel_pgd(uint64_t current_pgd_base, void *guest_kernel_va,
 		return -EINVAL;
 	}
 
-	kkm_mmu_copy_range(current_pgd_base, KKM_PGD_KERNEL_OFFSET,
-			   (uint64_t)guest_kernel_va, KKM_PGD_KERNEL_OFFSET,
-			   KKM_PGD_KERNEL_SIZE);
-
-	/*
-	 * set private area in kernel pml4 area
-	 */
-	kkm_mmu_set_entry((void *)guest_kernel_va, KKM_PGD_INDEX,
-			  kkm_mmu_kx.pgd_entry);
+	kkm_mmu_setup_one_pgd(current_pgd_base, guest_kernel_va, kernel_p4d_va);
 
 	/*
 	 * point to user pgd.
@@ -271,13 +336,9 @@ int kkm_mmu_copy_kernel_pgd(uint64_t current_pgd_base, void *guest_kernel_va,
 	 * user pml4 is odd page
 	 */
 	//current_pgd_base += PAGE_SIZE;
-	kkm_mmu_copy_range(current_pgd_base, KKM_PGD_KERNEL_OFFSET,
-			   (uint64_t)guest_payload_va, KKM_PGD_KERNEL_OFFSET,
-			   KKM_PGD_KERNEL_SIZE);
 
-	/* set private area in guest pml4 */
-	kkm_mmu_set_entry((void *)guest_payload_va, KKM_PGD_INDEX,
-			  kkm_mmu_kx.pgd_entry);
+	kkm_mmu_setup_one_pgd(current_pgd_base, guest_payload_va,
+			      payload_p4d_va);
 
 	return 0;
 }
@@ -289,17 +350,38 @@ int kkm_mmu_copy_kernel_pgd(uint64_t current_pgd_base, void *guest_kernel_va,
  * copy the above pml4 entry to point to 128TB in guest payload for stack and mmap
  */
 int kkm_mmu_sync(uint64_t current_pgd_base, void *guest_kernel_va,
-		 void *guest_payload_va, struct kkm_mmu_pml4e *guest)
+		 void *guest_payload_va, struct kkm_mmu_pml4e *guest,
+		 void *low_p4d_va, phys_addr_t low_p4d_pa)
 {
 	uint64_t native_kernel_entry = -1;
 	uint64_t guest_payload_entry = -1;
 	uint64_t new_guest_entry = -1;
+	uint64_t native_kernel_low_p4d_pa = 0;
+	uint64_t native_kernel_low_p4d_va = 0;
 
-	native_kernel_entry =
-		((uint64_t *)current_pgd_base)[KKM_PGD_MONITOR_PAYLOAD_ENTRY];
-	guest_payload_entry =
-		((uint64_t *)
-			 guest_payload_va)[KKM_PGD_GUEST_PAYLOAD_BOTTOM_ENTRY];
+	if (pgtable_l5_enabled() == true) {
+		/*
+		 * from kernel pgd get p4d pointer(virtual address) for KKM_PGD_LOW_P4D_ENTRY
+		 */
+
+		native_kernel_low_p4d_pa =
+			((uint64_t *)current_pgd_base)[KKM_PGD_LOW_P4D_ENTRY] &
+			KKM_PAGE_PA_MASK;
+		native_kernel_low_p4d_va =
+			(uint64_t)phys_to_virt(native_kernel_low_p4d_pa);
+
+		native_kernel_entry = ((uint64_t *)native_kernel_low_p4d_va)
+			[KKM_PGD_MONITOR_PAYLOAD_ENTRY];
+		guest_payload_entry =
+			((uint64_t *)
+				 low_p4d_va)[KKM_PGD_GUEST_PAYLOAD_BOTTOM_ENTRY];
+	} else {
+		native_kernel_entry =
+			((uint64_t *)
+				 current_pgd_base)[KKM_PGD_MONITOR_PAYLOAD_ENTRY];
+		guest_payload_entry = ((uint64_t *)guest_payload_va)
+			[KKM_PGD_GUEST_PAYLOAD_BOTTOM_ENTRY];
+	}
 
 	/*
 	 * if entries Physical Address are same, nothing to be done
@@ -315,28 +397,61 @@ int kkm_mmu_sync(uint64_t current_pgd_base, void *guest_kernel_va,
 	 */
 	new_guest_entry = native_kernel_entry & ~_PAGE_NX;
 
-	/*
-	 * keep kernel and user pgd same for payload area
-	 * entry 0 for code + data
-	 */
-	((uint64_t *)guest_kernel_va)[KKM_PGD_GUEST_PAYLOAD_BOTTOM_ENTRY] =
-		new_guest_entry;
-	((uint64_t *)guest_payload_va)[KKM_PGD_GUEST_PAYLOAD_BOTTOM_ENTRY] =
-		new_guest_entry;
+	if (pgtable_l5_enabled() == true) {
+		/*
+		 * insert pgd entry using low_p4d_pa
+		 * in guest_kernel and guest_payload pgd
+		 */
+		kkm_mmu_insert_page(guest_kernel_va, KKM_PGD_LOW_P4D_ENTRY,
+				    low_p4d_pa,
+				    _PAGE_USER | _PAGE_RW | _PAGE_PRESENT);
+		kkm_mmu_insert_page(guest_payload_va, KKM_PGD_LOW_P4D_ENTRY,
+				    low_p4d_pa,
+				    _PAGE_USER | _PAGE_RW | _PAGE_PRESENT);
 
-	/*
-	 * set entry 1 for guest va(vdso, vvar + code copied from km to payload)
-	 */
-	((uint64_t *)guest_kernel_va)[1] = guest->pgd_entry;
-	((uint64_t *)guest_payload_va)[1] = guest->pgd_entry;
+		/*
+		 * keep kernel and user pgd same for payload area
+		 * entry 0 for code + data
+		 */
+		((uint64_t *)low_p4d_va)[KKM_PGD_GUEST_PAYLOAD_BOTTOM_ENTRY] =
+			new_guest_entry;
 
-	/*
-	 * entry 255 for stack + mmap
-	 */
-	((uint64_t *)guest_kernel_va)[KKM_PGD_GUEST_PAYLOAD_TOP_ENTRY] =
-		new_guest_entry;
-	((uint64_t *)guest_payload_va)[KKM_PGD_GUEST_PAYLOAD_TOP_ENTRY] =
-		new_guest_entry;
+		/*
+		 * set entry 1 for guest va(vdso, vvar + code copied from km to payload)
+		 */
+		((uint64_t *)low_p4d_va)[1] = guest->pgd_entry;
+
+		/*
+		 * entry 255 for stack + mmap
+		 */
+		((uint64_t *)low_p4d_va)[KKM_PGD_GUEST_PAYLOAD_TOP_ENTRY] =
+			new_guest_entry;
+	} else {
+		/*
+		 * keep kernel and user pgd same for payload area
+		 * entry 0 for code + data
+		 */
+		((uint64_t *)
+			 guest_kernel_va)[KKM_PGD_GUEST_PAYLOAD_BOTTOM_ENTRY] =
+			new_guest_entry;
+		((uint64_t *)
+			 guest_payload_va)[KKM_PGD_GUEST_PAYLOAD_BOTTOM_ENTRY] =
+			new_guest_entry;
+
+		/*
+		 * set entry 1 for guest va(vdso, vvar + code copied from km to payload)
+		 */
+		((uint64_t *)guest_kernel_va)[1] = guest->pgd_entry;
+		((uint64_t *)guest_payload_va)[1] = guest->pgd_entry;
+
+		/*
+		 * entry 255 for stack + mmap
+		 */
+		((uint64_t *)guest_kernel_va)[KKM_PGD_GUEST_PAYLOAD_TOP_ENTRY] =
+			new_guest_entry;
+		((uint64_t *)guest_payload_va)[KKM_PGD_GUEST_PAYLOAD_TOP_ENTRY] =
+			new_guest_entry;
+	}
 
 	/*
 	 * fix memory alias created
@@ -349,39 +464,46 @@ int kkm_mmu_sync(uint64_t current_pgd_base, void *guest_kernel_va,
  * walk through kernel page table to identify physical address of faulted address
  * add to to guest kernel and payload page tables
  */
-bool kkm_kontext_mmu_update_priv_area(uint64_t guest_fault_address,
-				      uint64_t monitor_fault_address,
-				      uint64_t current_pgd_base,
-				      struct kkm_mmu_pml4e *guest)
+bool kkm_mmu_update_priv_area(uint64_t guest_fault_address,
+			      uint64_t monitor_fault_address,
+			      uint64_t current_pgd_base,
+			      struct kkm_mmu_pml4e *guest)
 {
 	bool ret_val = true;
 	uint64_t pgd_idx = pgd_index(monitor_fault_address);
+	uint64_t p4d_idx = p4d_index(monitor_fault_address);
 	uint64_t pud_idx = pud_index(monitor_fault_address);
 	uint64_t pmd_idx = pmd_index(monitor_fault_address);
 	uint64_t pte_idx = pte_index(monitor_fault_address);
 	uint64_t table_va = current_pgd_base;
 	uint64_t gva_pte_idx = pte_index(guest_fault_address);
 
-	/* 4th level */
-	if (kkm_kontext_mmu_get_table_va(&table_va, pgd_idx) != true) {
-		printk(KERN_NOTICE
-		       "kkm_kontext_mmu_update_priv_area: pgd failed\n");
+	/* top level */
+	if (kkm_mmu_get_table_va(&table_va, pgd_idx) != true) {
+		printk(KERN_NOTICE "kkm_mmu_update_priv_area: pgd failed\n");
 		ret_val = false;
 		goto end;
 	}
 
+	if (pgtable_l5_enabled() == true) {
+		if (kkm_mmu_get_table_va(&table_va, p4d_idx) != true) {
+			printk(KERN_NOTICE
+			       "kkm_mmu_update_priv_area: p4d failed\n");
+			ret_val = false;
+			goto end;
+		}
+	}
+
 	/* 3rd level */
-	if (kkm_kontext_mmu_get_table_va(&table_va, pud_idx) != true) {
-		printk(KERN_NOTICE
-		       "kkm_kontext_mmu_update_priv_area: pud failed\n");
+	if (kkm_mmu_get_table_va(&table_va, pud_idx) != true) {
+		printk(KERN_NOTICE "kkm_mmu_update_priv_area: pud failed\n");
 		ret_val = false;
 		goto end;
 	}
 
 	/* 2nd level */
-	if (kkm_kontext_mmu_get_table_va(&table_va, pmd_idx) != true) {
-		printk(KERN_NOTICE
-		       "kkm_kontext_mmu_update_priv_area: pmd failed\n");
+	if (kkm_mmu_get_table_va(&table_va, pmd_idx) != true) {
+		printk(KERN_NOTICE "kkm_mmu_update_priv_area: pmd failed\n");
 		ret_val = false;
 		goto end;
 	}
@@ -393,37 +515,10 @@ bool kkm_kontext_mmu_update_priv_area(uint64_t guest_fault_address,
 end:
 	if (ret_val == false) {
 		printk(KERN_NOTICE
-		       "kkm_kontext_mmu_update_priv_area: page walk failed kernel table va %llx guest address %llx pgd %llx pud %llx pmd %llx pte %llx\n",
-		       table_va, monitor_fault_address, pgd_idx, pud_idx,
-		       pmd_idx, pte_idx);
+		       "kkm_mmu_update_priv_area: page walk failed kernel table va %llx "
+		       "guest address %llx pgd %llx p4d %llx pud %llx pmd %llx pte %llx\n",
+		       table_va, monitor_fault_address, pgd_idx, p4d_idx,
+		       pud_idx, pmd_idx, pte_idx);
 	}
 	return ret_val;
-}
-
-bool kkm_kontext_mmu_get_table_va(uint64_t *table_va, int index)
-{
-	uint64_t entry;
-	uint64_t entry_pa;
-	uint64_t next_table_va;
-
-	/*
-	 * fetch entry from page table
-	 */
-	entry = ((uint64_t *)(*table_va))[index];
-
-	/*
-	 * get physical address of page from entry
-	 */
-	entry_pa = kkm_mmu_entry_pa(entry);
-
-	/*
-	 * convert physical address of page to kernel virtual address
-	 */
-	next_table_va = (uint64_t)phys_to_virt(entry_pa);
-
-	if (entry & _PAGE_PRESENT) {
-		*table_va = next_table_va;
-		return true;
-	}
-	return false;
 }

--- a/kkm/kkm_mmu.h
+++ b/kkm/kkm_mmu.h
@@ -58,8 +58,11 @@
 /* use unused kernel virtual address for kkm fixed mapping */
 #define KKM_PRIVATE_START_VA (0xFFFFFE8000000000ULL)
 
+/* index in PGD for KX P4D when 5 level page tables are used */
+#define KKM_KX_PGD_P4D_INDEX (511)
+
 /* pml4 table entry offset for KKM_PRIVATE_START_VA */
-#define KKM_PGD_INDEX (509)
+#define KKM_KX_PGD_INDEX (509)
 
 /* page table indices start */
 
@@ -155,6 +158,7 @@
  *     virtual address 0 for code growing up
  *     virtual address for stack growing down
  */
+#define KKM_PGD_LOW_P4D_ENTRY (0)
 /* bytes offset into pml4 table for 16TB(monitor guest mapping) */
 #ifndef KM_GPA_AT_16T
 #define KKM_PGD_MONITOR_PAYLOAD_ENTRY (0)
@@ -203,12 +207,8 @@ void kkm_mmu_flush_tlb_one_page(uint64_t addr);
 int kkm_create_pml4(struct kkm_mmu_pml4e *kmu, uint64_t address);
 void kkm_cleanup_pml4(struct kkm_mmu_pml4e *kmu);
 
-uint64_t kkm_mmu_get_pgd_entry(void);
-int kkm_mmu_get_per_cpu_start_index(int cpu_index);
-void kkm_mmu_insert_page(void *pt_va, int index, phys_addr_t pa,
-			 uint64_t flags);
-void kkm_mmu_set_guest_area(int cpu_index, phys_addr_t pa0, phys_addr_t pa1, phys_addr_t pa2,
-			    phys_addr_t pa3);
+void kkm_mmu_set_guest_area(int cpu_index, phys_addr_t pa0, phys_addr_t pa1,
+			    phys_addr_t pa2, phys_addr_t pa3);
 void *kkm_mmu_get_cur_cpu_guest_va(int cpu_index);
 
 void *kkm_mmu_get_idt_va(void);
@@ -217,13 +217,14 @@ void kkm_mmu_set_kx_global_info(phys_addr_t idt_pa, phys_addr_t text_page0_pa,
 				phys_addr_t kx_global_pa);
 
 int kkm_mmu_copy_kernel_pgd(uint64_t current_pgd_base, void *guest_kernel_va,
-			    void *guest_payload_va);
+			    void *guest_payload_va, void *kernel_p4d_va,
+			    void *payload_p4d_va);
 int kkm_mmu_sync(uint64_t current_pgd_base, void *guest_kernel_va,
-		 void *guest_payload_va, struct kkm_mmu_pml4e *guest);
-bool kkm_kontext_mmu_update_priv_area(uint64_t guest_fault_address,
-				      uint64_t monitor_fault_address,
-				      uint64_t current_pgd_base,
-				      struct kkm_mmu_pml4e *guest);
-bool kkm_kontext_mmu_get_table_va(uint64_t *table_va, int index);
+		 void *guest_payload_va, struct kkm_mmu_pml4e *guest,
+		 void *low_p4d_va, phys_addr_t low_p4d_pa);
+bool kkm_mmu_update_priv_area(uint64_t guest_fault_address,
+			      uint64_t monitor_fault_address,
+			      uint64_t current_pgd_base,
+			      struct kkm_mmu_pml4e *guest);
 
 #endif /* __KKM_MMU_H__ */


### PR DESCRIPTION
some refactor due to conflict of old names with 4 level.
support for 5 level page tables

I am still reviewing the code for issues.

one test is still failing and working on fixing that.
gdb_sharedlib(dynamic): gdb shared libary related remote commands